### PR TITLE
Optionally disable dalle image storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ Once TalkTurbo is added to your server you can talk to the bot by @ing it or usi
 
 `--sync-app-commands` - Sync new or udpated app commands with Discord 
 
-`--no-user-identifier` - do *not* send a user's unique hash to OpenAI with each request. 
+`--no-user-identifier` - Do *not* send a user's unique hash to OpenAI with each request. 
+
+`--disable-image-storage` - Do not store dalle images locally.  Image prompts and hashes may still be logged. 
 
 ## Slash Commands
 Slash commands can be used within a Discord server to control the bot.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "TalkTurbo"
-version = "0.0.5"
+version = "0.0.6"
 authors = [
   {name = "James Kroner", email = "contactmeongithubplease@example.com"},
 ]

--- a/src/TalkTurbo/Turbo.py
+++ b/src/TalkTurbo/Turbo.py
@@ -77,6 +77,13 @@ parser.add_argument(
     dest="dalle_timeout",
 )
 
+parser.add_argument(
+    "--disable-image-storage",
+    action="store_true",
+    help="Do not store generated Dalle images.  Image hash and user identifier may still be logged elsewhere.",
+    dest="disable_image_storage",
+)
+
 args = parser.parse_args()
 
 
@@ -439,6 +446,14 @@ async def generate_image(
     logger.info(f"interaction {interaction_id}: generated image {image_path}")
 
     await interaction.followup.send(file=discord.File(image_path))
+
+    # clean up dalle file if requested
+    if args.disable_image_storage:
+        os.remove(path=image_path)
+        logger.info(
+            f"interaction {interaction_id}: unlinking image stored at {image_path}"
+        )
+
     logger.info(f"interaction {interaction_id}: resolved")
 
 


### PR DESCRIPTION
Dalle images can take up too much directory space over time.  Adding an optional flag that unlinks the image file after returning it to the user if a flag is passed.