### PR TITLE
implement guild-based models

### DIFF
--- a/src/TalkTurbo/CompletionAssistant.py
+++ b/src/TalkTurbo/CompletionAssistant.py
@@ -26,7 +26,9 @@ class CompletionAssistant:
         CompletionAssistant.INITIALIZED = True
 
     @staticmethod
-    def get_chat_completion(context: ChatContext) -> ChatContext:
+    def get_chat_completion(
+        context: ChatContext, adapter: ApiAdapter = None
+    ) -> ChatContext:
         """
         Get a chat completion from the adapter.
 
@@ -37,7 +39,11 @@ class CompletionAssistant:
                 "CompletionAssistant has not been initialized. Please set the adapter first."
             )
 
-        response = CompletionAssistant.ADAPTER.get_chat_completion(context)
+        # use the static adapter if one is not passed in
+        if not adapter:
+            adapter = CompletionAssistant.ADAPTER
+
+        response = adapter.get_chat_completion(context)
 
         context.add_message(response)
 

--- a/src/TalkTurbo/TurboGuild.py
+++ b/src/TalkTurbo/TurboGuild.py
@@ -1,7 +1,9 @@
 """TurboGuilds track context and usage for a Discord Guild"""
 
-from TalkTurbo.ChatContext import ChatContext
 import logging
+
+from TalkTurbo.ApiAdapters.ApiAdapter import ApiAdapter
+from TalkTurbo.ChatContext import ChatContext
 from TalkTurbo.Messages import SystemMessage
 
 
@@ -16,11 +18,18 @@ class TurboGuild:
         "If asked, you are wearing sassy pants."
     )
 
-    def __init__(self, id, chat_context: ChatContext = None) -> None:
+    def __init__(
+        self,
+        id,
+        name: str = None,
+        chat_context: ChatContext = None,
+        api_adapter: ApiAdapter = None,
+    ) -> None:
         self.id = id
         self.chat_context = chat_context or ChatContext(
             system_prompt=TurboGuild.DEFAULT_SYSTEM_PROMPT
         )
+        self.api_adapter = api_adapter
 
 
 class TurboGuildMap:


### PR DESCRIPTION
Each guild now tracks its own ApiAdapter.  If none is set then the default (gpt-3.5-turbo) is used. 