### PR TITLE
add better env examples to docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "TalkTurbo"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   { name = "Jim Kroner", email = "contactmeongithubplease@example.com" },
 ]


### PR DESCRIPTION
closes #36.

Also added an example of using `ChatContext` with different `ApiAdapters`. 

 