### PR TITLE
35 add llama and mixtral support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ requires = [
   "openai~=1.3",
   "pytest",
   "anthropic~=0.20",
-  "google-generativeai"
+  "google-generativeai",
+  "groq"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ openai~=1.3
 pytest
 anthropic~=0.20
 google-generativeai
+groq

--- a/src/TalkTurbo/ApiAdapters/GroqAdapter.py
+++ b/src/TalkTurbo/ApiAdapters/GroqAdapter.py
@@ -1,0 +1,48 @@
+"""Adapter for Groq's API."""
+
+from groq import Groq
+
+from TalkTurbo.ApiAdapters.ApiAdapter import ApiAdapter
+from TalkTurbo.ChatContext import ChatContext
+from TalkTurbo.Messages import ContentMessage, MessageFactory, SystemMessage
+
+
+class GroqAdapter(ApiAdapter):
+    """Adapter for Groq's API."""
+
+    # https://console.groq.com/docs/models
+    AVAILABLE_MODELS = [
+        "llama3-8b-8192",  # meta
+        "llama3-70b-8192",  # meta
+        "mixtral-8x7b-32768",  # mistral
+        "gemma-7b-it",  # google
+    ]
+
+    def __init__(
+        self, api_token, model_name=AVAILABLE_MODELS[0], max_tokens=4096
+    ) -> None:
+        super().__init__(
+            api_token=api_token, model_name=model_name, max_tokens=max_tokens
+        )
+        self._groq_client = Groq(api_key=self.api_token)
+
+    def get_chat_completion(self, context: ChatContext) -> ContentMessage:
+        completion = self._groq_client.chat.completions.create(
+            messages=context.get_messages_as_list(), model=self.model_name
+        )
+
+        if not completion:
+            return SystemMessage(
+                "_(turbo's host here: turbo didn't have anything to say :bluefootbooby:)_"
+            )
+
+        response = completion.choices[0].message
+
+        return MessageFactory.create_message(response.content, response.role)
+
+    def convert_context_to_api_format(self, context: ChatContext):
+        return [
+            message
+            for message in context.messages
+            if message.role.value in ["user", "assistant", "system"]
+        ]

--- a/src/TalkTurbo/Turbo.py
+++ b/src/TalkTurbo/Turbo.py
@@ -11,6 +11,7 @@ from dotenv import load_dotenv
 
 from TalkTurbo.ApiAdapters.AnthropicAdapter import AnthropicAdapter
 from TalkTurbo.ApiAdapters.GoogleAdapter import GoogleAdapter
+from TalkTurbo.ApiAdapters.GroqAdapter import GroqAdapter
 from TalkTurbo.ApiAdapters.OpenAIAdapter import OpenAIAdapter
 from TalkTurbo.CompletionAssistant import CompletionAssistant
 from TalkTurbo.LoggerGenerator import LoggerGenerator
@@ -94,6 +95,7 @@ DISCORD_SECRET_TOKEN = os.getenv("DISCORD_SECRET_KEY")
 OPENAI_SECRET_TOKEN = os.getenv("OPENAI_SECRET_KEY")
 ANT_SECRET_TOKEN = os.environ.get("ANTHROPIC_SECRET_KEY", None)
 GOOGLE_SECRET_TOKEN = os.environ.get("GOOGLE_SECRET_KEY", None)
+GROQ_SECRET_TOKEN = os.environ.get("GROQ_SECRET_KEY", None)
 GUILD_ID = os.getenv("GUILD_ID")
 
 # load the model assistant - this will get removed soon in favor of the completion assistant
@@ -295,6 +297,7 @@ async def list_models(interaction: discord.Interaction):
         OpenAIAdapter.AVAILABLE_MODELS
         + AnthropicAdapter.AVAILABLE_MODELS
         + GoogleAdapter.AVAILABLE_MODELS
+        + GroqAdapter.AVAILABLE_MODELS
     )
     await interaction.response.send_message(f"available models: {models}")
 
@@ -333,6 +336,10 @@ async def set_model(interaction: discord.Interaction, model: str = "gpt-3.5-turb
     elif model in GoogleAdapter.AVAILABLE_MODELS:
         turbo_guild.api_adapter = GoogleAdapter(
             api_token=GOOGLE_SECRET_TOKEN, model_name=model
+        )
+    elif model in GroqAdapter.AVAILABLE_MODELS:
+        turbo_guild.api_adapter = GroqAdapter(
+            api_token=GROQ_SECRET_TOKEN, model_name=model
         )
     else:
         logger.warning("model %s not found", model)


### PR DESCRIPTION
closes #35 

Adds support for a variety of models served by [groq](https://groq.com/)

```
turbo on  35-add-llama-and-mixtral-support [$!?] is 📦 v0.2.0 via 🐍 v3.11.1 (venv)
❯ python .\src\groqtest.py
>>> prompt: hey! I'm Larry
>>> current model: (meta) llama3-8b-8192
Hey Larry! It's great to meet you! Is there something I can help you with or would you like to chat?

>>> current model: (meta) llama3-70b-8192
Hey Larry! It's nice to meet you! Is there something I can help you with or would you like to chat about something in particular? I'm all ears!

>>> current model: (mistral) mixtral-8x7b-32768
Hello Larry! It's nice to meet you. How can I help you today? If you have any questions or need assistance with something, feel free to ask.

>>> current model: (google) gemma-7b-it
Hey Larry! 👋 It's great to meet you. What brings you here today? 😉
```