### PR TITLE
53 ci bugfixes

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,17 +13,17 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.11"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pre-commit
-    - name: Run pre-commit
-      run: pre-commit run --all-files
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --all-files
 
   build:
     needs: pre-commit
@@ -33,16 +33,19 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Run tests
-      run: |
-        pip install .
-        coverage run -m pytest
-        coverage report
-    - name: Build package
-      run: |
-        python3 -m build
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+      - name: Run tests
+        run: |
+          coverage run -m pytest
+          coverage report
+      - name: Build package
+        run: |
+          python3 -m build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,9 @@ repos:
       additional_dependencies:
         - tomli
       exclude: '^pdm\.lock$'
+
+# Ensure GitHub Actions workflows are valid
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.7.1
+  hooks:
+    - id: actionlint

--- a/makefile
+++ b/makefile
@@ -23,10 +23,10 @@ docker-build:
 	docker build -t turbo:dev_latest .
 
 act-x86:
-	act -j pre-commit
+	act -j pre-commit -j build
 
 act-arm:
-	act -j pre-commit --container-architecture linux/arm64
+	act -j pre-commit -j build --container-architecture linux/arm64
 
 setup: install-dev
 	pre-commit install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "TalkTurbo"
-version = "0.6.1"
+version = "0.6.2"
 authors = [
   { name = "Jim Kroner", email = "contactmeongithubplease@example.com" },
 ]


### PR DESCRIPTION
Install dev requirements during CI builds. Add a pre-commit check for GitHub actions. Run build job with `make act` commands. 