### PR TITLE
fix invalid reference during docker deployment

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -124,5 +124,5 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ env.DOCKER_USERNAME }}/${{ env.DOCKER_REPOSITORY }}:latest
-            ${{ env.DOCKER_USERNAME }}/${{ env.DOCKER_REPOSITORY }}:${{ steps.get_version.outputs.version }}
+            jbkroner/talkturbo:latest
+            jbkroner/talkturbo:${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
An env variable is getting substituted for `***` as it's technically a secret.  Because it's just my docker username I'm going to hard-code it. 