### PR TITLE
72 set default model to 4o mini, add o1-preview and o1-mini support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Make sure your `.env` file is in the current directory and contains the necessar
 - `/estop`: Shut down the bot (use at your discretion for spam, abuse, or other problems)
 - `/list_models`: List available models
 - `/list_current_model`: Show the model TalkTurbo is currently using
-- `/set_model`: Set the model that TalkTurbo will use
+- `/set_model`: Set the model that TalkTurbo will use (defaults to `4o-mini`)
 
 ## Context Tracking
 
@@ -123,7 +123,7 @@ TalkTurbo tracks conversation context to maintain topic relevance. Key points:
 - Newest messages are kept, oldest are removed when limit is reached
 - Messages older than 24 hours are dropped
 - System prompt is never removed from context
-- Context limit can be increased up to 4096 tokens for `gpt-3.5-turbo` (note: this will increase API usage and costs)
+- Context limit can be increased up to 4096 tokens
 
 ## Moderation
 

--- a/src/TalkTurbo/ApiAdapters/OpenAIAdapter.py
+++ b/src/TalkTurbo/ApiAdapters/OpenAIAdapter.py
@@ -10,12 +10,19 @@ from TalkTurbo.Messages import ContentMessage, MessageFactory, SystemMessage
 class OpenAIAdapter(ApiAdapter):
     """Adapter for OpenAI's API."""
 
-    AVAILABLE_MODELS = ["gpt-3.5-turbo", "gpt-4", "gpt-4-turbo-preview", "gpt-4o"]
+    AVAILABLE_MODELS = [
+        "gpt-4o-mini",
+        "o1-preview",
+        "o1-mini",
+        "gpt-4",
+        "gpt-4-turbo-preview",
+        "gpt-4o",
+    ]
 
     def __init__(
         self,
         api_token: str,
-        model_name: str = "gpt-3.5-turbo",
+        model_name: str = "gpt-4o-mini",
         max_tokens=4096,
     ):
         super().__init__(api_token=api_token, model_name=model_name, max_tokens=max_tokens)


### PR DESCRIPTION
Set the default model to 4o-mini, it is cheaper and more capable than 3.5 turbo.

Also adds support for the new o1 models. 